### PR TITLE
refactor(fe): optimize state access

### DIFF
--- a/apps/client/src/components/qna/QuestionItem.tsx
+++ b/apps/client/src/components/qna/QuestionItem.tsx
@@ -30,13 +30,19 @@ interface QuestionItemProps {
 function QuestionItem({ question, onQuestionSelect }: QuestionItemProps) {
   const navigate = useNavigate();
 
-  const { addToast } = useToastStore();
-
   const { Modal: CreateQuestion, openModal: openCreateQuestionModal } = useModal(
     <CreateQuestionModal question={question} />,
   );
 
-  const { sessionToken, sessionId, isHost, expired, removeQuestion, updateQuestion, setFromDetail } = useSessionStore();
+  const sessionToken = useSessionStore((state) => state.sessionToken);
+  const sessionId = useSessionStore((state) => state.sessionId);
+  const isHost = useSessionStore((state) => state.isHost);
+  const expired = useSessionStore((state) => state.expired);
+  const removeQuestion = useSessionStore((state) => state.removeQuestion);
+  const updateQuestion = useSessionStore((state) => state.updateQuestion);
+  const setFromDetail = useSessionStore((state) => state.setFromDetail);
+
+  const addToast = useToastStore((state) => state.addToast);
 
   const handleSelectQuestionId = () => {
     if (!sessionId) return;

--- a/apps/client/src/features/modal/modal.hook.tsx
+++ b/apps/client/src/features/modal/modal.hook.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useContext, useMemo, useState } from 'react';
+import { ReactNode, useCallback, useContext, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import Background from '@/features/modal/Background';
@@ -8,35 +8,36 @@ export const useModal = (children: ReactNode) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
 
-  const openModal = () => {
+  const openModal = useCallback(() => {
     setIsOpen(true);
     setIsClosing(false);
-  };
+  }, []);
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setIsClosing(true);
     setTimeout(() => setIsOpen(false), 150);
-  };
-
-  const contextValue = useMemo(() => ({ openModal, closeModal }), []);
+  }, []);
 
   const Modal = useMemo(() => {
     if (!isOpen) return null;
     return createPortal(
-      <ModalContext.Provider value={contextValue}>
+      <ModalContext.Provider value={{ openModal, closeModal }}>
         <Background>
           <div className={`modal-content ${isClosing ? 'animate-modalClose' : 'animate-modalOpen'}`}>{children}</div>
         </Background>
       </ModalContext.Provider>,
       document.body,
     );
-  }, [isOpen, isClosing, children, contextValue]);
+  }, [isOpen, openModal, closeModal, isClosing, children]);
 
-  return {
-    Modal,
-    openModal,
-    closeModal,
-  };
+  return useMemo(
+    () => ({
+      Modal,
+      openModal,
+      closeModal,
+    }),
+    [Modal, openModal, closeModal],
+  );
 };
 
 export const useModalContext = () => {

--- a/apps/client/src/features/socket/socket.context.tsx
+++ b/apps/client/src/features/socket/socket.context.tsx
@@ -15,7 +15,9 @@ interface SocketProviderProps {
 }
 
 export function SocketProvider({ children }: SocketProviderProps) {
-  const { expired, sessionId, sessionToken } = useSessionStore();
+  const expired = useSessionStore((state) => state.expired);
+  const sessionId = useSessionStore((state) => state.sessionId);
+  const sessionToken = useSessionStore((state) => state.sessionToken);
 
   const [socket, setSocket] = useState<SocketService>();
 

--- a/apps/client/src/routes/session/$sessionId/index.tsx
+++ b/apps/client/src/routes/session/$sessionId/index.tsx
@@ -6,7 +6,7 @@ import { loadSessionData, useSessionStore } from '@/features/session';
 const LazyQuestionList = React.lazy(() => import('@/components').then((module) => ({ default: module.QuestionList })));
 
 function SessionComponent() {
-  const { sessionTitle } = useSessionStore();
+  const sessionTitle = useSessionStore((state) => state.sessionTitle);
 
   useEffect(() => {
     if (sessionTitle) {


### PR DESCRIPTION
## 개요

채팅 입력시, 질문 목록이 렌더링이 진행되는 문제를 수정했습니다.

이 문제를 많은 데이터가 있을 때 렌더링이 진행되며 사용자 경험이 저하되는 것을 확인할 수 있었습니다.

서로 다른 컴포넌트에서 상태 변화시 렌더링이 진행되는 것도 좋지 않지만, 가상 스크롤과 같은 기법을 적용하여 렌더링되는 요소를 줄이는 것도 추가할 필요가 있다고 생각됩니다.

이후 작업에서 채팅, 질문 목록, 답변 목록에서 가상 스크롤을 추가하여 렌더링되는 요소의 수를 제한하여 성능 최적화를 진행하고자 합니다.

또한 렌더링 관련 추가적인 최적화가 필요하다고 생각이 드는 부분이 많습니다. 우선적으로 성능에 크게 영향을 미치는 부분부터 시작하여 개선 예정입니다.

| 개선 전 | 개선 후 |
|--------|--------|
| ![개선 전](https://github.com/user-attachments/assets/3d9e3661-83f7-4039-abbf-c7fa51fa44dc) | ![개선 후](https://github.com/user-attachments/assets/fed32f03-1bcd-4241-ac0b-efb85ec08980) |

## 이슈

- close #21 