### PR TITLE
fix(fe): refactor authentication checks to use accessToken

### DIFF
--- a/apps/client/src/components/Header.tsx
+++ b/apps/client/src/components/Header.tsx
@@ -10,7 +10,7 @@ import { Button, SignInModal, SignUpModal } from '@/components';
 function Header() {
   const { isLogin, clearAuthInformation: clearAccessToken } = useAuthStore(
     useShallow((state) => ({
-      isLogin: state.isLogin,
+      isLogin: state.accessToken != null,
       clearAuthInformation: state.clearAuthInformation,
     })),
   );
@@ -47,12 +47,12 @@ function Header() {
           <div className='flex items-center justify-center gap-2.5'>
             <Button
               className='hover:bg-gray-200 hover:text-white hover:transition-all'
-              onClick={isLogin() ? handleLogout : openSignInModal}
+              onClick={isLogin ? handleLogout : openSignInModal}
             >
-              <p className='text-base font-bold text-black'>{isLogin() ? '로그아웃' : '로그인'}</p>
+              <p className='text-base font-bold text-black'>{isLogin ? '로그아웃' : '로그인'}</p>
             </Button>
-            <Button className='bg-indigo-600' onClick={isLogin() ? () => navigate({ to: '/my' }) : openSignUpModal}>
-              <p className='text-base font-bold text-white'>{isLogin() ? '세션 기록' : '회원가입'}</p>
+            <Button className='bg-indigo-600' onClick={isLogin ? () => navigate({ to: '/my' }) : openSignUpModal}>
+              <p className='text-base font-bold text-white'>{isLogin ? '세션 기록' : '회원가입'}</p>
             </Button>
           </div>
         </div>

--- a/apps/client/src/features/auth/auth.store.ts
+++ b/apps/client/src/features/auth/auth.store.ts
@@ -3,13 +3,11 @@ import { create } from 'zustand';
 interface AuthStore {
   userId?: number;
   accessToken?: string;
-  isLogin: () => boolean;
   setAuthInformation: ({ userId, accessToken }: { userId?: number; accessToken?: string }) => void;
   clearAuthInformation: () => void;
 }
 
-export const useAuthStore = create<AuthStore>((set, get) => ({
-  isLogin: () => get().accessToken != null,
+export const useAuthStore = create<AuthStore>((set) => ({
   setAuthInformation: ({ userId, accessToken }: { userId?: number; accessToken?: string }) =>
     set({ userId, accessToken }),
   clearAuthInformation: () => set({ userId: undefined, accessToken: undefined }),

--- a/apps/client/src/features/session/session.util.ts
+++ b/apps/client/src/features/session/session.util.ts
@@ -31,7 +31,7 @@ export async function loadSessionData(options: LoadSessionOptions) {
   } = sessionStore;
 
   // 1) [옵션] 로그인/refresh
-  if (!skipRefresh && !authStore.isLogin()) {
+  if (!skipRefresh && !authStore.accessToken) {
     try {
       const res = await refresh();
       authStore.setAuthInformation(res);

--- a/apps/client/src/pages/HomePage.tsx
+++ b/apps/client/src/pages/HomePage.tsx
@@ -7,7 +7,7 @@ import { useModal } from '@/features/modal';
 import { Button, CreateSessionModal, FeatureCard } from '@/components';
 
 function HomePage() {
-  const isLogin = useAuthStore((state) => state.isLogin);
+  const isLogin = useAuthStore((state) => state.accessToken != null);
 
   const { Modal: CreateSession, openModal: openCreateSessionModal } = useModal(<CreateSessionModal />);
 
@@ -25,12 +25,12 @@ function HomePage() {
           </div>
           <div className='group relative flex'>
             <Button
-              className={`${isLogin() ? 'bg-indigo-600' : 'cursor-not-allowed bg-indigo-300'}`}
-              onClick={isLogin() ? openCreateSessionModal : undefined}
+              className={`${isLogin ? 'bg-indigo-600' : 'cursor-not-allowed bg-indigo-300'}`}
+              onClick={isLogin ? openCreateSessionModal : undefined}
             >
               <div className='text-base font-bold text-white'>새로운 세션 만들기</div>
             </Button>
-            {isLogin() ? undefined : (
+            {isLogin ? undefined : (
               <span className='absolute top-1/2 flex w-full translate-y-full items-center justify-center rounded-md bg-indigo-600 p-1 text-sm font-bold text-white opacity-0 transition-opacity group-hover:opacity-100'>
                 로그인 후 이용 가능
               </span>

--- a/apps/client/src/routes/index.tsx
+++ b/apps/client/src/routes/index.tsx
@@ -7,9 +7,9 @@ const LazyHomePage = React.lazy(() => import('@/pages').then((module) => ({ defa
 
 export const Route = createFileRoute('/')({
   beforeLoad: () => {
-    const { isLogin, setAuthInformation } = useAuthStore.getState();
+    const { accessToken, setAuthInformation } = useAuthStore.getState();
 
-    if (!isLogin())
+    if (!accessToken)
       refresh()
         .then((res) => {
           setAuthInformation(res);

--- a/apps/client/src/routes/my.tsx
+++ b/apps/client/src/routes/my.tsx
@@ -12,9 +12,9 @@ export const Route = createFileRoute('/my')({
     </React.Suspense>
   ),
   beforeLoad: () => {
-    const { isLogin, setAuthInformation } = useAuthStore.getState();
+    const { accessToken, setAuthInformation } = useAuthStore.getState();
 
-    if (!isLogin()) {
+    if (!accessToken) {
       return refresh()
         .then((res) => {
           setAuthInformation(res);


### PR DESCRIPTION
## 개요

네비게이션 바에서 렌더링이 일어나야하지만, 일어나지 않는 경우를 수정했습니다.
- 내부적으로 액세스토큰의 값이 변경되면 로그인이 되었다고 판단하여 화면이 렌더링되길 기대하지만, `isLogin` 메서드를 이용하고 있어, 해당 메서드는 다시 재생성되지 않아, 렌더링이 일어나지 않았습니다.
- 액세스토큰 값에 따른 파생 상태를 생성하여 해당 상태로 렌더링이 일어나도록 수정했습니다.

## 이슈

- close #31
