### PR TITLE
feat(be): implement ai request-restriction guard

### DIFF
--- a/apps/server/src/ai/ai.controller.ts
+++ b/apps/server/src/ai/ai.controller.ts
@@ -5,6 +5,7 @@ import { AiService } from './ai.service';
 import { CreateHistoryDto } from './dto/create-history.dto';
 import { ImproveQuestionDto } from './dto/improve-question.dto';
 import { ShortenQuestionDto } from './dto/shorten-question.dto';
+import { AiRequestValidationGuard } from './guards/restrict-request.guard';
 import { CreateHistorySwagger } from './swagger/create-history.swagger';
 import { ImproveQuestionSwagger } from './swagger/improve-question.swagger';
 import { ShortenQuestionSwagger } from './swagger/shorten-question.swagger';
@@ -12,6 +13,7 @@ import { ShortenQuestionSwagger } from './swagger/shorten-question.swagger';
 import { SessionTokenValidationGuard } from '@common/guards/session-token-validation.guard';
 
 @Controller('ai')
+@UseGuards(AiRequestValidationGuard)
 export class AiController {
   constructor(private readonly aiService: AiService) {}
 

--- a/apps/server/src/ai/ai.module.ts
+++ b/apps/server/src/ai/ai.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 
 import { AiController } from './ai.controller';
 import { AiService } from './ai.service';
+import { AiRequestValidationModule } from './guards/restrict-request.module';
 
 import { SessionTokenModule } from '@common/guards/session-token.module';
 import { PrismaModule } from '@prisma-alias/prisma.module';
 
 @Module({
-  imports: [PrismaModule, SessionTokenModule],
+  imports: [PrismaModule, SessionTokenModule, AiRequestValidationModule],
   providers: [AiService],
   controllers: [AiController],
 })

--- a/apps/server/src/ai/guards/restrict-request.guard.ts
+++ b/apps/server/src/ai/guards/restrict-request.guard.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Inject, Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+
+@Injectable()
+export class AiRequestValidationGuard implements CanActivate {
+  private readonly ttl = 3;
+
+  constructor(@Inject('REDIS_RESTRICT_TOKEN') private readonly restrictRedisClient: Redis) {}
+
+  async validateAiRequest(token: string) {
+    const exists = await this.restrictRedisClient.get(token);
+    if (Number(exists) === 1) {
+      throw new ForbiddenException('저희의 토큰은 소중합니다.');
+    }
+    await this.restrictRedisClient.set(token, 1, 'EX', this.ttl);
+  }
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const token = request.body?.token || request.query?.token;
+
+    await this.validateAiRequest(token);
+    return true;
+  }
+}

--- a/apps/server/src/ai/guards/restrict-request.module.ts
+++ b/apps/server/src/ai/guards/restrict-request.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+
+import { AiRequestValidationGuard } from './restrict-request.guard';
+
+@Module({
+  providers: [AiRequestValidationGuard],
+  exports: [AiRequestValidationGuard],
+})
+export class AiRequestValidationModule {}

--- a/apps/server/src/common/redis.module.ts
+++ b/apps/server/src/common/redis.module.ts
@@ -34,7 +34,17 @@ import Redis from 'ioredis';
         });
       },
     },
+    {
+      provide: 'REDIS_RESTRICT_TOKEN',
+      useFactory: () => {
+        return new Redis({
+          host: process.env.REDIS_HOST,
+          port: Number(process.env.REDIS_PORT),
+          db: 3,
+        });
+      },
+    },
   ],
-  exports: ['REDIS_SESSION', 'REDIS_TOKEN', 'REDIS_REFRESH_TOKEN'],
+  exports: ['REDIS_SESSION', 'REDIS_TOKEN', 'REDIS_REFRESH_TOKEN', 'REDIS_RESTRICT_TOKEN'],
 })
 export class RedisModule {}


### PR DESCRIPTION
## 개요
- 사용자가 악의적으로 AI 요청을 짧은 시간안에 여러번 보낼 경우 제한하는 기능을 만들었습니다
- redis를 사용하여 같은 사용자의 ai 요청이 3초안에 올 경우 반환되도록 하였습니다.

## 이슈
- close #75 