### PR TITLE
fix(be): update socket server prisma schema

### DIFF
--- a/apps/socket-server/prisma/schema.prisma
+++ b/apps/socket-server/prisma/schema.prisma
@@ -93,6 +93,8 @@ model QuestionLike {
 
   question              Question         @relation("QuestionLikes", fields: [questionId], references: [questionId], onDelete: Cascade)
   createUserTokenEntity UserSessionToken @relation("TokenQuestionLikes", fields: [createUserToken], references: [token])
+
+  @@unique([questionId, createUserToken])
 }
 
 model Reply {
@@ -117,18 +119,44 @@ model ReplyLike {
 
   reply                 Reply            @relation("ReplyLikes", fields: [replyId], references: [replyId], onDelete: Cascade)
   createUserTokenEntity UserSessionToken @relation("TokenReplyLikes", fields: [createUserToken], references: [token])
+
+  @@unique([replyId, createUserToken])
+}
+
+enum AbuseState {
+  PENDING
+  SAFE
+  BLOCKED
 }
 
 model Chatting {
-  chattingId      Int      @id @default(autoincrement()) @map("chatting_id")
-  createUserToken String   @map("create_user_token")
+  chattingId      Int         @id @default(autoincrement()) @map("chatting_id")
+  createUserToken String      @map("create_user_token")
   body            String
-  createdAt       DateTime @default(now()) @map("created_at")
-  sessionId       String   @map("session_id")
+  createdAt       DateTime    @default(now()) @map("created_at")
+  sessionId       String      @map("session_id")
+  abuse           AbuseState  @default(PENDING)
 
   session               Session          @relation("SessionChattings", fields: [sessionId], references: [sessionId])
   createUserTokenEntity UserSessionToken @relation("TokenChattings", fields: [createUserToken], references: [token])
 
   @@index([sessionId])
   @@index([sessionId, chattingId(Sort.desc)])
+}
+
+model Prompt {
+  name    String  @id
+  content String
+
+  PromptHistory PromptHistory[] @relation("promptHistories")
+}
+
+model PromptHistory {
+  historyId   Int     @id @default(autoincrement()) @map("history_id")
+  request     String  
+  response    String
+  promptName  String  @map("prompt_name")
+  result      String
+
+  prompt      Prompt  @relation("promptHistories", fields: [promptName], references: [name])
 }


### PR DESCRIPTION
## 개요

- prisma 타입 추론이 안 되어 socket server가 죽는 문제를 해결했습니다.
- 서버 로그:
```
src/chats/test-chats.mock.ts:1:10 - error TS2305: Module '"@prisma/client"' has no exported member 'AbuseState'.

1 import { AbuseState } from '@prisma/client';
           ~~~~~~~~~~

Found 1 error(s).

 ELIFECYCLE  Command failed with exit code 1.
```

## 없슈