### PR TITLE
refactor(be): implement permission and ownership guards for replies and questions

### DIFF
--- a/apps/server/src/common/decorators/require-ownership.decorator.ts
+++ b/apps/server/src/common/decorators/require-ownership.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const OWNERSHIP_KEY = 'ownership';
+
+export const RequireOwnership = () => SetMetadata(OWNERSHIP_KEY, true);

--- a/apps/server/src/common/decorators/require-permission.decorator.ts
+++ b/apps/server/src/common/decorators/require-permission.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const PERMISSION_KEY = 'permission';
+
+export const RequirePermission = (permission: number) => SetMetadata(PERMISSION_KEY, permission);

--- a/apps/server/src/common/guards/ownership.guard.ts
+++ b/apps/server/src/common/guards/ownership.guard.ts
@@ -1,0 +1,36 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { OWNERSHIP_KEY } from '@common/decorators/require-ownership.decorator';
+
+@Injectable()
+export class OwnershipGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requireOwnership = this.reflector.get<boolean>(OWNERSHIP_KEY, context.getHandler());
+
+    if (!requireOwnership) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const token = request.body?.token || request.query?.token;
+
+    if (!token) {
+      throw new ForbiddenException('사용자 토큰이 필요합니다.');
+    }
+
+    const resource = request.question || request.reply;
+
+    if (!resource) {
+      throw new ForbiddenException('리소스 정보를 찾을 수 없습니다.');
+    }
+
+    if (resource.createUserToken !== token) {
+      throw new ForbiddenException('권한이 없습니다.');
+    }
+
+    return true;
+  }
+}

--- a/apps/server/src/common/guards/permission-or-ownership.guard.spec.ts
+++ b/apps/server/src/common/guards/permission-or-ownership.guard.spec.ts
@@ -1,0 +1,180 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { PermissionOrOwnershipGuard } from './permission-or-ownership.guard';
+
+import { SessionsAuthRepository } from '@sessions-auth/sessions-auth.repository';
+
+describe('PermissionOrOwnershipGuard', () => {
+  let guard: PermissionOrOwnershipGuard;
+  let reflector: jest.Mocked<Reflector>;
+  let sessionAuthRepository: jest.Mocked<SessionsAuthRepository>;
+
+  const mockExecutionContext = {
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn().mockReturnValue({
+        body: {},
+        query: {},
+      }),
+    }),
+    getHandler: jest.fn(),
+  } as unknown as ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PermissionOrOwnershipGuard,
+        {
+          provide: Reflector,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: SessionsAuthRepository,
+          useValue: {
+            findByTokenWithPermissions: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<PermissionOrOwnershipGuard>(PermissionOrOwnershipGuard);
+    reflector = module.get(Reflector);
+    sessionAuthRepository = module.get(SessionsAuthRepository);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('가드가 정의되어 있어야 한다', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('필요한 권한이 없으면 true를 반환해야 한다', async () => {
+    reflector.get.mockReturnValue(null);
+
+    const result = await guard.canActivate(mockExecutionContext);
+
+    expect(result).toBe(true);
+  });
+
+  it('토큰이 없으면 ForbiddenException을 발생시켜야 한다', async () => {
+    reflector.get.mockReturnValue(1);
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          body: {},
+          query: {},
+        }),
+      }),
+    };
+
+    await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+    expect(sessionAuthRepository.findByTokenWithPermissions).not.toHaveBeenCalled();
+  });
+
+  it('필요한 권한이 있으면 true를 반환해야 한다', async () => {
+    reflector.get.mockReturnValue(1);
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          body: { token: 'valid-token' },
+          query: {},
+        }),
+      }),
+    };
+
+    const mockUserWithPermission = {
+      role: {
+        permissions: [{ permissionId: 1 }],
+      },
+    };
+
+    sessionAuthRepository.findByTokenWithPermissions.mockResolvedValue(mockUserWithPermission as any);
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(sessionAuthRepository.findByTokenWithPermissions).toHaveBeenCalledWith('valid-token');
+  });
+
+  it('권한이 없어도 리소스 소유자면 true를 반환해야 한다', async () => {
+    reflector.get.mockReturnValue(1);
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          body: { token: 'owner-token' },
+          query: {},
+          reply: { createUserToken: 'owner-token' },
+        }),
+      }),
+    };
+
+    const mockUserWithoutPermission = {
+      role: {
+        permissions: [],
+      },
+    };
+
+    sessionAuthRepository.findByTokenWithPermissions.mockResolvedValue(mockUserWithoutPermission as any);
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(sessionAuthRepository.findByTokenWithPermissions).toHaveBeenCalledWith('owner-token');
+  });
+
+  it('권한도 없고 소유자도 아니면 ForbiddenException을 발생시켜야 한다', async () => {
+    reflector.get.mockReturnValue(1);
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          body: { token: 'other-token' },
+          query: {},
+          reply: { createUserToken: 'owner-token' },
+        }),
+      }),
+    };
+
+    const mockUserWithoutPermission = {
+      role: {
+        permissions: [],
+      },
+    };
+
+    sessionAuthRepository.findByTokenWithPermissions.mockResolvedValue(mockUserWithoutPermission as any);
+
+    await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+    expect(sessionAuthRepository.findByTokenWithPermissions).toHaveBeenCalledWith('other-token');
+  });
+
+  it('리소스 정보가 없으면 ForbiddenException을 발생시켜야 한다', async () => {
+    reflector.get.mockReturnValue(1);
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          body: { token: 'token' },
+          query: {},
+        }),
+      }),
+    };
+
+    const mockUserWithoutPermission = {
+      role: {
+        permissions: [],
+      },
+    };
+
+    sessionAuthRepository.findByTokenWithPermissions.mockResolvedValue(mockUserWithoutPermission as any);
+
+    await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/apps/server/src/common/guards/permission-or-ownership.guard.ts
+++ b/apps/server/src/common/guards/permission-or-ownership.guard.ts
@@ -1,0 +1,54 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { PERMISSION_KEY } from '@common/decorators/require-permission.decorator';
+import { SessionsAuthRepository } from '@sessions-auth/sessions-auth.repository';
+
+@Injectable()
+export class PermissionOrOwnershipGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly sessionAuthRepository: SessionsAuthRepository,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredPermission = this.reflector.get<number>(PERMISSION_KEY, context.getHandler());
+
+    if (!requiredPermission) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const token = request.body?.token || request.query?.token;
+
+    if (!token) {
+      throw new ForbiddenException('사용자 토큰이 필요합니다.');
+    }
+
+    try {
+      const { role } = await this.sessionAuthRepository.findByTokenWithPermissions(token);
+      const hasPermission = role.permissions.some(({ permissionId }) => permissionId === requiredPermission);
+
+      if (hasPermission) {
+        return true;
+      }
+
+      const resource = request.question || request.reply;
+
+      if (!resource) {
+        throw new ForbiddenException('리소스 정보를 찾을 수 없습니다.');
+      }
+
+      if (resource.createUserToken !== token) {
+        throw new ForbiddenException('권한이 없습니다.');
+      }
+
+      return true;
+    } catch (error) {
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
+      throw new ForbiddenException('권한 확인 중 오류가 발생했습니다.');
+    }
+  }
+}

--- a/apps/server/src/common/guards/permission.guard.ts
+++ b/apps/server/src/common/guards/permission.guard.ts
@@ -1,0 +1,44 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { PERMISSION_KEY } from '@common/decorators/require-permission.decorator';
+import { SessionsAuthRepository } from '@sessions-auth/sessions-auth.repository';
+
+@Injectable()
+export class PermissionGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly sessionAuthRepository: SessionsAuthRepository,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredPermission = this.reflector.get<number>(PERMISSION_KEY, context.getHandler());
+
+    if (!requiredPermission) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const token = request.body?.token || request.query?.token;
+
+    if (!token) {
+      throw new ForbiddenException('사용자 토큰이 필요합니다.');
+    }
+
+    try {
+      const { role } = await this.sessionAuthRepository.findByTokenWithPermissions(token);
+      const hasPermission = role.permissions.some(({ permissionId }) => permissionId === requiredPermission);
+
+      if (!hasPermission) {
+        throw new ForbiddenException('권한이 없습니다.');
+      }
+
+      return true;
+    } catch (error) {
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
+      throw new ForbiddenException('권한 확인 중 오류가 발생했습니다.');
+    }
+  }
+}

--- a/apps/server/src/common/guards/permission.module.ts
+++ b/apps/server/src/common/guards/permission.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+import { OwnershipGuard } from './ownership.guard';
+import { PermissionOrOwnershipGuard } from './permission-or-ownership.guard';
+import { PermissionGuard } from './permission.guard';
+
+import { PrismaModule } from '@prisma-alias/prisma.module';
+import { SessionsAuthRepository } from '@sessions-auth/sessions-auth.repository';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [PermissionGuard, OwnershipGuard, PermissionOrOwnershipGuard, SessionsAuthRepository],
+  exports: [PermissionGuard, OwnershipGuard, PermissionOrOwnershipGuard, SessionsAuthRepository],
+})
+export class PermissionModule {}

--- a/apps/server/src/questions/questions.module.ts
+++ b/apps/server/src/questions/questions.module.ts
@@ -4,6 +4,7 @@ import { QuestionsController } from './questions.controller';
 import { QuestionsRepository } from './questions.repository';
 import { QuestionsService } from './questions.service';
 
+import { PermissionModule } from '@common/guards/permission.module';
 import { SessionTokenModule } from '@common/guards/session-token.module';
 import { PrismaModule } from '@prisma-alias/prisma.module';
 import { QuestionExistenceGuard } from '@questions/guards/question-existence.guard';
@@ -11,7 +12,7 @@ import { QuestionOwnershipGuard } from '@questions/guards/question-ownership.gua
 import { RepliesRepository } from '@replies/replies.repository';
 
 @Module({
-  imports: [PrismaModule, SessionTokenModule],
+  imports: [PrismaModule, SessionTokenModule, PermissionModule],
   controllers: [QuestionsController],
   providers: [QuestionsService, QuestionsRepository, QuestionExistenceGuard, QuestionOwnershipGuard, RepliesRepository],
   exports: [QuestionExistenceGuard, QuestionsRepository],

--- a/apps/server/src/replies/guards/reply-existence.guard.spec.ts
+++ b/apps/server/src/replies/guards/reply-existence.guard.spec.ts
@@ -1,0 +1,131 @@
+import { ExecutionContext, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ReplyExistenceGuard } from './reply-existence.guard';
+
+import { RepliesRepository } from '@replies/replies.repository';
+
+describe('ReplyExistenceGuard', () => {
+  let guard: ReplyExistenceGuard;
+  let repliesRepository: jest.Mocked<RepliesRepository>;
+
+  const mockExecutionContext = {
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn().mockReturnValue({
+        params: { replyId: '1' },
+        body: { sessionId: 'session123' },
+        query: {},
+      }),
+    }),
+  } as unknown as ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReplyExistenceGuard,
+        {
+          provide: RepliesRepository,
+          useValue: {
+            findReplyByIdAndSessionId: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    guard = module.get<ReplyExistenceGuard>(ReplyExistenceGuard);
+    repliesRepository = module.get(RepliesRepository);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('가드가 정의되어 있어야 한다', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('답글이 존재하면 true를 반환하고 request에 답글 정보를 추가해야 한다', async () => {
+    const mockReply = {
+      replyId: 1,
+      body: 'Test reply',
+      createUserToken: 'token',
+      sessionId: 'session123',
+      questionId: 1,
+      createdAt: new Date(),
+      deleted: false,
+    };
+
+    const mockRequest: any = {
+      params: { replyId: '1' },
+      body: { sessionId: 'session123' },
+      query: {},
+    };
+
+    const mockGetRequest = jest.fn().mockReturnValue(mockRequest);
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: mockGetRequest,
+      }),
+    };
+
+    repliesRepository.findReplyByIdAndSessionId.mockResolvedValue(mockReply);
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(repliesRepository.findReplyByIdAndSessionId).toHaveBeenCalledWith(1, 'session123');
+    expect(mockRequest.reply).toEqual(mockReply);
+  });
+
+  it('답글이 존재하지 않으면 NotFoundException을 발생시켜야 한다', async () => {
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          params: { replyId: '999' },
+          body: { sessionId: 'session123' },
+          query: {},
+        }),
+      }),
+    };
+
+    repliesRepository.findReplyByIdAndSessionId.mockResolvedValue(null);
+
+    await expect(guard.canActivate(context)).rejects.toThrow(NotFoundException);
+    expect(repliesRepository.findReplyByIdAndSessionId).toHaveBeenCalledWith(999, 'session123');
+  });
+
+  it('query에서 sessionId를 가져올 수 있어야 한다', async () => {
+    const mockReply = {
+      replyId: 1,
+      body: 'Test reply',
+      createUserToken: 'token',
+      sessionId: 'session123',
+      questionId: 1,
+      createdAt: new Date(),
+      deleted: false,
+    };
+
+    const mockRequest: any = {
+      params: { replyId: '1' },
+      body: {},
+      query: { sessionId: 'session123' },
+    };
+
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue(mockRequest),
+      }),
+    };
+
+    repliesRepository.findReplyByIdAndSessionId.mockResolvedValue(mockReply);
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(repliesRepository.findReplyByIdAndSessionId).toHaveBeenCalledWith(1, 'session123');
+    expect(mockRequest.reply).toEqual(mockReply);
+  });
+});

--- a/apps/server/src/replies/guards/reply-ownership.guard.spec.ts
+++ b/apps/server/src/replies/guards/reply-ownership.guard.spec.ts
@@ -1,0 +1,80 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ReplyOwnershipGuard } from './reply-ownership.guard';
+
+describe('ReplyOwnershipGuard', () => {
+  let guard: ReplyOwnershipGuard;
+
+  const mockExecutionContext = {
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn().mockReturnValue({
+        body: {},
+        query: {},
+      }),
+    }),
+  } as unknown as ExecutionContext;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ReplyOwnershipGuard],
+    }).compile();
+
+    guard = module.get<ReplyOwnershipGuard>(ReplyOwnershipGuard);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('가드가 정의되어 있어야 한다', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('답글 소유자가 맞으면 true를 반환해야 한다', async () => {
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          body: { token: 'owner-token' },
+          reply: { createUserToken: 'owner-token' },
+        }),
+      }),
+    };
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('답글 소유자가 아니면 ForbiddenException을 발생시켜야 한다', async () => {
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          body: { token: 'other-token' },
+          reply: { createUserToken: 'owner-token' },
+        }),
+      }),
+    };
+
+    await expect(guard.canActivate(context)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('query에서 토큰을 가져올 수 있어야 한다', async () => {
+    const context = {
+      ...mockExecutionContext,
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({
+          body: {},
+          query: { token: 'owner-token' },
+          reply: { createUserToken: 'owner-token' },
+        }),
+      }),
+    };
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+});

--- a/apps/server/src/replies/replies.controller.spec.ts
+++ b/apps/server/src/replies/replies.controller.spec.ts
@@ -1,0 +1,287 @@
+import { ForbiddenException, INestApplication, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+
+import { ReplyExistenceGuard } from './guards/reply-existence.guard';
+import { ReplyOwnershipGuard } from './guards/reply-ownership.guard';
+import { RepliesController } from './replies.controller';
+import { RepliesService } from './replies.service';
+
+import { PermissionOrOwnershipGuard } from '@common/guards/permission-or-ownership.guard';
+import { SessionTokenValidationGuard } from '@common/guards/session-token-validation.guard';
+import { TransformInterceptor } from '@common/interceptors/transform.interceptor';
+import { QuestionExistenceGuard } from '@questions/guards/question-existence.guard';
+
+// requestSocket 모킹
+jest.mock('@common/request-socket', () => ({
+  requestSocket: jest.fn(),
+}));
+
+describe('RepliesController 통합 테스트', () => {
+  let app: INestApplication;
+  let repliesService: jest.Mocked<RepliesService>;
+  let sessionTokenValidationGuard: jest.Mocked<SessionTokenValidationGuard>;
+  let questionExistenceGuard: jest.Mocked<QuestionExistenceGuard>;
+  let replyExistenceGuard: jest.Mocked<ReplyExistenceGuard>;
+  let replyOwnershipGuard: jest.Mocked<ReplyOwnershipGuard>;
+  let permissionOrOwnershipGuard: jest.Mocked<PermissionOrOwnershipGuard>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [RepliesController],
+      providers: [
+        {
+          provide: RepliesService,
+          useValue: {
+            createReply: jest.fn(),
+            updateBody: jest.fn(),
+            deleteReply: jest.fn(),
+            toggleLike: jest.fn(),
+            getLikesCount: jest.fn(),
+            validateHost: jest.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(SessionTokenValidationGuard)
+      .useValue({
+        canActivate: jest.fn(),
+      })
+      .overrideGuard(QuestionExistenceGuard)
+      .useValue({
+        canActivate: jest.fn(),
+      })
+      .overrideGuard(ReplyExistenceGuard)
+      .useValue({
+        canActivate: jest.fn(),
+      })
+      .overrideGuard(ReplyOwnershipGuard)
+      .useValue({
+        canActivate: jest.fn(),
+      })
+      .overrideGuard(PermissionOrOwnershipGuard)
+      .useValue({
+        canActivate: jest.fn(),
+      })
+      .overrideInterceptor(TransformInterceptor)
+      .useValue({
+        intercept: jest.fn((context, next) => next.handle()),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    repliesService = moduleFixture.get(RepliesService);
+    sessionTokenValidationGuard = moduleFixture.get(SessionTokenValidationGuard);
+    questionExistenceGuard = moduleFixture.get(QuestionExistenceGuard);
+    replyExistenceGuard = moduleFixture.get(ReplyExistenceGuard);
+    replyOwnershipGuard = moduleFixture.get(ReplyOwnershipGuard);
+    permissionOrOwnershipGuard = moduleFixture.get(PermissionOrOwnershipGuard);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('POST /replies (답글 생성)', () => {
+    const createReplyDto = {
+      body: 'Test reply',
+      questionId: 1,
+      token: 'valid-token',
+      sessionId: 'session123',
+    };
+
+    it('유효한 데이터로 답글 생성 성공', async () => {
+      const mockCreatedAt = new Date('2025-07-18T12:29:53.875Z');
+      const mockReply = {
+        replyId: 1,
+        body: 'Test reply',
+        createdAt: mockCreatedAt,
+        isOwner: true,
+        likesCount: 0,
+        liked: false,
+        deleted: false,
+        questionId: 1,
+        nickname: 'TestUser',
+        userId: 1,
+      };
+
+      // 가드들이 모두 통과하도록 설정
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      questionExistenceGuard.canActivate.mockResolvedValue(true);
+
+      repliesService.createReply.mockResolvedValue(mockReply);
+      repliesService.validateHost.mockResolvedValue(true);
+
+      const response = await request(app.getHttpServer()).post('/replies').send(createReplyDto).expect(201);
+
+      // Date 직렬화 문제 해결: 날짜를 문자열로 변환하여 비교
+      const expectedReply = { ...mockReply, isHost: true, createdAt: mockCreatedAt.toISOString() };
+      expect(response.body.reply).toEqual(expectedReply);
+      expect(repliesService.createReply).toHaveBeenCalledWith(createReplyDto);
+      expect(repliesService.validateHost).toHaveBeenCalledWith('valid-token');
+    });
+
+    it('토큰 검증 실패 시 403 에러', async () => {
+      sessionTokenValidationGuard.canActivate.mockRejectedValue(new ForbiddenException('토큰이 유효하지 않습니다'));
+
+      await request(app.getHttpServer()).post('/replies').send(createReplyDto).expect(403);
+
+      expect(repliesService.createReply).not.toHaveBeenCalled();
+    });
+
+    it('질문이 존재하지 않으면 404 에러', async () => {
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      questionExistenceGuard.canActivate.mockRejectedValue(new NotFoundException('질문이 존재하지 않습니다'));
+
+      await request(app.getHttpServer()).post('/replies').send(createReplyDto).expect(404);
+
+      expect(repliesService.createReply).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /replies/:replyId/body (답글 수정)', () => {
+    const updateReplyDto = {
+      body: 'Updated reply',
+      token: 'owner-token',
+      sessionId: 'session123',
+    };
+
+    it('소유자가 답글 수정 성공', async () => {
+      const mockCreatedAt = new Date('2025-07-18T12:29:53.924Z');
+      const mockUpdatedReply = {
+        replyId: 1,
+        body: 'Updated reply',
+        createUserToken: 'owner-token',
+        sessionId: 'session123',
+        questionId: 1,
+        createdAt: mockCreatedAt,
+        deleted: false,
+      };
+
+      // 가드들이 모두 통과하도록 설정
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      replyExistenceGuard.canActivate.mockResolvedValue(true);
+      replyOwnershipGuard.canActivate.mockResolvedValue(true);
+
+      repliesService.updateBody.mockResolvedValue(mockUpdatedReply);
+
+      const response = await request(app.getHttpServer()).patch('/replies/1/body').send(updateReplyDto).expect(200);
+
+      // Date 직렬화 문제 해결: 날짜를 문자열로 변환하여 비교
+      const expectedReply = { ...mockUpdatedReply, createdAt: mockCreatedAt.toISOString() };
+      expect(response.body.reply).toEqual(expectedReply);
+      expect(repliesService.updateBody).toHaveBeenCalledWith(1, updateReplyDto);
+    });
+
+    it('답글이 존재하지 않으면 404 에러', async () => {
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      replyExistenceGuard.canActivate.mockRejectedValue(new NotFoundException('답글이 존재하지 않습니다'));
+
+      await request(app.getHttpServer()).patch('/replies/999/body').send(updateReplyDto).expect(404);
+
+      expect(repliesService.updateBody).not.toHaveBeenCalled();
+    });
+
+    it('답글 소유자가 아니면 403 에러', async () => {
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      replyExistenceGuard.canActivate.mockResolvedValue(true);
+      replyOwnershipGuard.canActivate.mockRejectedValue(new ForbiddenException('권한이 없습니다'));
+
+      await request(app.getHttpServer())
+        .patch('/replies/1/body')
+        .send({ ...updateReplyDto, token: 'other-token' })
+        .expect(403);
+
+      expect(repliesService.updateBody).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE /replies/:replyId (답글 삭제)', () => {
+    it('권한이 있는 사용자가 답글 삭제 성공', async () => {
+      const mockDeletedReply = {
+        replyId: 1,
+        createUserToken: 'owner-token',
+        sessionId: 'session123',
+        questionId: 1,
+        body: 'Test reply',
+        createdAt: new Date(),
+        deleted: true,
+      };
+
+      // 가드들이 모두 통과하도록 설정
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      replyExistenceGuard.canActivate.mockResolvedValue(true);
+      permissionOrOwnershipGuard.canActivate.mockResolvedValue(true);
+
+      repliesService.deleteReply.mockResolvedValue(mockDeletedReply);
+
+      await request(app.getHttpServer())
+        .delete('/replies/1')
+        .query({ token: 'admin-token', sessionId: 'session123' })
+        .expect(200);
+
+      expect(repliesService.deleteReply).toHaveBeenCalledWith(1);
+    });
+
+    it('권한이 없는 사용자는 답글 삭제 실패', async () => {
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      replyExistenceGuard.canActivate.mockResolvedValue(true);
+      permissionOrOwnershipGuard.canActivate.mockRejectedValue(new ForbiddenException('권한이 없습니다'));
+
+      await request(app.getHttpServer())
+        .delete('/replies/1')
+        .query({ token: 'user-token', sessionId: 'session123' })
+        .expect(403);
+
+      expect(repliesService.deleteReply).not.toHaveBeenCalled();
+    });
+
+    it('답글이 존재하지 않으면 404 에러', async () => {
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      replyExistenceGuard.canActivate.mockRejectedValue(new NotFoundException('답글이 존재하지 않습니다'));
+
+      await request(app.getHttpServer())
+        .delete('/replies/999')
+        .query({ token: 'admin-token', sessionId: 'session123' })
+        .expect(404);
+
+      expect(repliesService.deleteReply).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /replies/:replyId/likes (답글 좋아요)', () => {
+    it('답글 좋아요 토글 성공', async () => {
+      const mockToggleResult = { liked: true, questionId: 1 };
+      const mockLikesCount = 5;
+
+      sessionTokenValidationGuard.canActivate.mockResolvedValue(true);
+      repliesService.toggleLike.mockResolvedValue(mockToggleResult);
+      repliesService.getLikesCount.mockResolvedValue(mockLikesCount);
+
+      const response = await request(app.getHttpServer())
+        .post('/replies/1/likes')
+        .send({ token: 'user-token', sessionId: 'session123' })
+        .expect(201);
+
+      expect(response.body).toEqual({
+        liked: true,
+        likesCount: 5,
+      });
+      expect(repliesService.toggleLike).toHaveBeenCalledWith(1, 'user-token');
+      expect(repliesService.getLikesCount).toHaveBeenCalledWith(1);
+    });
+
+    it('토큰 검증 실패 시 403 에러', async () => {
+      sessionTokenValidationGuard.canActivate.mockRejectedValue(new ForbiddenException('토큰이 유효하지 않습니다'));
+
+      await request(app.getHttpServer())
+        .post('/replies/1/likes')
+        .send({ token: 'invalid-token', sessionId: 'session123' })
+        .expect(403);
+
+      expect(repliesService.toggleLike).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/src/replies/replies.module.ts
+++ b/apps/server/src/replies/replies.module.ts
@@ -4,13 +4,14 @@ import { RepliesController } from './replies.controller';
 import { RepliesRepository } from './replies.repository';
 import { RepliesService } from './replies.service';
 
+import { PermissionModule } from '@common/guards/permission.module';
 import { SessionTokenModule } from '@common/guards/session-token.module';
 import { PrismaModule } from '@prisma-alias/prisma.module';
 import { QuestionsModule } from '@questions/questions.module';
 import { SessionsRepository } from '@sessions/sessions.repository';
 
 @Module({
-  imports: [PrismaModule, SessionTokenModule, QuestionsModule],
+  imports: [PrismaModule, SessionTokenModule, PermissionModule, QuestionsModule],
   controllers: [RepliesController],
   providers: [RepliesService, RepliesRepository, SessionsRepository],
 })

--- a/apps/server/src/replies/replies.service.ts
+++ b/apps/server/src/replies/replies.service.ts
@@ -1,11 +1,9 @@
-import { ForbiddenException, Injectable } from '@nestjs/common';
-import { Reply } from '@prisma/client';
+import { Injectable } from '@nestjs/common';
 
 import { CreateReplyDto } from './dto/create-reply.dto';
 import { UpdateReplyBodyDto } from './dto/update-reply.dto';
 import { RepliesRepository } from './replies.repository';
 
-import { Permissions } from '@common/roles/permissions';
 import { Roles } from '@common/roles/roles';
 import { SessionsAuthRepository } from '@sessions-auth/sessions-auth.repository';
 
@@ -38,12 +36,7 @@ export class RepliesService {
     return await this.repliesRepository.updateBody(replyId, body);
   }
 
-  async deleteReply(replyId: number, token: string, reply: Reply) {
-    const { role } = await this.sessionAuthRepository.findByTokenWithPermissions(token);
-    const granted = role.permissions.some(({ permissionId }) => permissionId === Permissions.DELETE_REPLY);
-
-    if (!granted && reply.createUserToken !== token) throw new ForbiddenException('권한이 없습니다.');
-
+  async deleteReply(replyId: number) {
     return await this.repliesRepository.deleteReply(replyId);
   }
 


### PR DESCRIPTION
## 개요

- 기존의 개별적인 권한 체크 로직을 통합된 RBAC 가드 시스템으로 리팩토링
  - 권한 기반 데코레이터 추가
  - 서비스 레이어 단순화
    - 권한 체크 로직 제거
- 테스트 개선
  - 새로운 가드 테스트 추가
    - 권한/소유권 조합 시나리오별 테스트 케이스
  - 기존 테스트 정리
    - 비즈니스 로직에만 집중하는 테스트로 개선
