### PR TITLE
fix(be): update Dockerfiles to resolve prisma version issue

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 EXPOSE 3000
 
-CMD ["sh", "-c", "pnpx prisma generate && pnpx prisma migrate deploy && pnpm run build && pnpm run start:prod:http"]
+CMD ["sh", "-c", "pnpm run db:generate && pnpm run db:migrate && pnpm run build && pnpm run start:prod:http"]

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,7 +18,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "db:generate": "prisma generate",
+    "db:migrate": "prisma migrate deploy"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.693.0",

--- a/apps/socket-server/Dockerfile
+++ b/apps/socket-server/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 EXPOSE 4000
 
-CMD ["sh", "-c", "pnpx prisma generate && pnpm run build && pnpm run start:prod:ws"]
+CMD ["sh", "-c", "pnpm run db:generate && pnpm run db:migrate && pnpm run build && pnpm run start:prod:ws"]

--- a/apps/socket-server/package.json
+++ b/apps/socket-server/package.json
@@ -18,7 +18,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "db:generate": "prisma generate",
+    "db:migrate": "prisma migrate deploy"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.693.0",


### PR DESCRIPTION
## 개요

- 이전에 AWS로 이사갈 때 prisma 버전이 맞지 않는 문제가 있었죠.
- 그때 급하게 EC2 내에서 dockerfile을 수정했었는데, 코드에도 반영해두면 좋을 것 같아 수정해보았습니다.
